### PR TITLE
Adding new fingerprint to context

### DIFF
--- a/inspetor/build.gradle
+++ b/inspetor/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.12.0'
     implementation 'com.google.android.gms:play-services-analytics:17.0.0'
     implementation 'com.android.support:support-annotations:28.0.0'
+    implementation 'com.scottyab:rootbeer-lib:0.0.7'
     testImplementation 'org.assertj:assertj-core:3.12.2'
     testImplementation 'org.jetbrains.kotlin:kotlin-stdlib:1.3.41'
     testImplementation 'junit:junit:4.12'

--- a/inspetor/deploy.gradle
+++ b/inspetor/deploy.gradle
@@ -5,7 +5,7 @@ apply from: 'keystore.gradle'
 ext {
     groupId = 'com.github.inspetor'
     artifactId = "inspetor"
-    libVersion = "1.2.1"
+    libVersion = "1.2.3"
 }
 
 version = libVersion
@@ -60,9 +60,9 @@ bintray {
         name = "inspetor"
         version {
             name = libVersion
-            desc = 'This is updated version 1.2.1 of Inspetor Android Library.'
+            desc = 'This is updated version 1.2.3 of Inspetor Android Library.'
             released = new Date()
-            vcsTag = '1.2.1'
+            vcsTag = '1.2.3'
         }
     }
 }

--- a/inspetor/src/main/java/com/inspetor/InspetorDependencies.kt
+++ b/inspetor/src/main/java/com/inspetor/InspetorDependencies.kt
@@ -22,6 +22,7 @@ object InspetorDependencies {
 
     // Schema versions
     const val FRONTEND_CONTEXT_SCHEMA_VERSION:       String = "iglu:com.inspetor/inspetor_context/jsonschema/1-0-0"
+    const val FRONTEND_FINGERPRINT_SCHEMA_VERSION:   String = "iglu:com.inspetor/inspetor_fingerprint_frontent/jsonschema/1-0-0"
     const val FRONTEND_ACCOUNT_SCHEMA_VERSION:       String = "iglu:com.inspetor/inspetor_account_frontend/jsonschema/1-0-0"
     const val FRONTEND_AUTH_SCHEMA_VERSION:          String = "iglu:com.inspetor/inspetor_auth_frontend/jsonschema/1-0-1"
     const val FRONTEND_EVENT_SCHEMA_VERSION:         String = "iglu:com.inspetor/inspetor_event_frontend/jsonschema/1-0-0"


### PR DESCRIPTION
Trying to identify the device through a better fingerprint than the one provided by snowplow, this PR implements one using the android device id (unique and only changes with factory reset) and more info like is rooted or if the OS is running in an emulator.