### PR TITLE
[LEG-653, LEG-188] Deprecating password reset + Hiding LegitiDevEnv + git-cz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /legiti/keystore.gradle
 /inspetor-android.iml
 /legiti-android.iml
+/node_modules

--- a/changelog.config.js
+++ b/changelog.config.js
@@ -1,0 +1,64 @@
+module.exports = {
+    "disableEmoji": true,
+    "list": [
+      "test",
+      "feat",
+      "fix",
+      "chore",
+      "docs",
+      "refactor",
+      "style",
+      "ci",
+      "perf"
+    ],
+    "maxMessageLength": 64,
+    "minMessageLength": 3,
+    "questions": [
+      "type",
+      "scope",
+      "subject",
+      "body",
+      "breaking",
+      "issues",
+      "lerna"
+    ],
+    "scopes": [],
+    "types": {
+      "chore": {
+        "description": "Build process or auxiliary tool changes",
+        "value": "chore"
+      },
+      "ci": {
+        "description": "CI related changes",
+        "value": "ci"
+      },
+      "docs": {
+        "description": "Documentation only changes",
+        "value": "docs"
+      },
+      "feat": {
+        "description": "A new feature",
+        "value": "feat"
+      },
+      "fix": {
+        "description": "A bug fix",
+        "value": "fix"
+      },
+      "perf": {
+        "description": "A code change that improves performance",
+        "value": "perf"
+      },
+      "refactor": {
+        "description": "A code change that neither fixes a bug or adds a feature",
+        "value": "refactor"
+      },
+      "style": {
+        "description": "Markup, white-space, formatting, missing semi-colons...",
+        "value": "style"
+      },
+      "test": {
+        "description": "Adding missing tests",
+        "value": "test"
+      }
+    }
+  };

--- a/legiti/deploy.gradle
+++ b/legiti/deploy.gradle
@@ -5,7 +5,7 @@ apply from: 'keystore.gradle'
 ext {
     groupId = 'com.legiti'
     artifactId = "legiti"
-    libVersion = "1.0.3"
+    libVersion = "1.1.0"
 }
 
 version = libVersion

--- a/legiti/src/main/java/com/legiti/LegitiClient.kt
+++ b/legiti/src/main/java/com/legiti/LegitiClient.kt
@@ -3,6 +3,7 @@ package com.legiti
 import android.content.Context
 import android.os.Build
 import android.util.Base64
+import android.util.Log
 import com.legiti.helpers.*
 import com.legiti.services.LegitiService
 import java.text.SimpleDateFormat
@@ -96,8 +97,14 @@ class LegitiClient : LegitiService {
         legitiResource?.trackOrderAction(data, OrderAction.ORDER_CREATE_ACTION)
     }
 
+    @Deprecated(
+        message = "This function is deprecated and will be removed in a future version of the library",
+        level = DeprecationLevel.WARNING
+    )
     override fun trackPasswordReset(userId: String) {
         this.hasConfig()
+
+        Log.w("LEGITI", "This function is deprecated and will be removed in a future version of the library")
 
         val data = this.createJson(id = userId, prefix = "pass_reset", idSuffix = "user_id")
         legitiResource?.trackPasswordResetAction(data, PasswordAction.PASSWORD_RESET_ACTION)

--- a/legiti/src/main/java/com/legiti/LegitiClient.kt
+++ b/legiti/src/main/java/com/legiti/LegitiClient.kt
@@ -24,8 +24,28 @@ class LegitiClient : LegitiService {
         this.androidContext = null
     }
 
+
+    @Deprecated(
+        message = "This function is deprecated and will be removed in a future version of the library",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+            expression = "Legiti.sharedInstance().setup(authToken)",
+            imports = ["com.legiti.Legiti"]
+        )
+    )
     override fun setup(authToken: String, legitiDevEnv: Boolean) {
-        this.legitiConfig = LegitiConfig(authToken, legitiDevEnv)
+        this.legitiConfig = LegitiConfig(authToken)
+
+        if (this.androidContext != null) {
+            this.setContext(androidContext!!)
+        } else {
+            throw ContextNotSetup("Legiti Exception 9003: Could not get the context please pass it to the setContext function.")
+        }
+
+    }
+
+    override fun setup(authToken: String) {
+        this.legitiConfig = LegitiConfig(authToken)
 
         if (this.androidContext != null) {
             this.setContext(androidContext!!)

--- a/legiti/src/main/java/com/legiti/LegitiConfig.kt
+++ b/legiti/src/main/java/com/legiti/LegitiConfig.kt
@@ -5,12 +5,22 @@ import org.json.JSONException
 import android.util.Base64
 import com.legiti.helpers.InvalidCredentials
 
-class LegitiConfig(val authToken: String, val legitiDevEnv: Boolean) {
+
+class LegitiConfig(var authToken: String) {
+
+    internal var legitiDevEnv: Boolean = false
+    private val INTERNAL_KEYWORD: String = "internal_"
 
     init {
         require(isValid(authToken)) {
             throw InvalidCredentials("Legiti Exception 9002: authToken not valid")
         }
+        this.authToken = checkIfInternal(this.authToken)
+    }
+
+    private fun checkIfInternal(authToken: String): String {
+        if (authToken.contains(this.INTERNAL_KEYWORD)) this.legitiDevEnv = true
+        return authToken.removePrefix(this.INTERNAL_KEYWORD)
     }
 
 
@@ -33,6 +43,7 @@ class LegitiConfig(val authToken: String, val legitiDevEnv: Boolean) {
 
             return true
         }
+
 
         fun getPrincipalId(authTokenPart: String): String? {
             val decodedAuthToken = String(Base64.decode(authTokenPart, Base64.NO_PADDING))

--- a/legiti/src/main/java/com/legiti/helpers/SnowplowManager.kt
+++ b/legiti/src/main/java/com/legiti/helpers/SnowplowManager.kt
@@ -56,6 +56,7 @@ object SnowplowManager {
                 .geoLocationContext(true)
                 .applicationContext(true)
                 .mobileContext(true)
+                .applicationCrash(false)
                 .build()
         ) ?: throw fail()
     }

--- a/legiti/src/main/java/com/legiti/services/LegitiService.kt
+++ b/legiti/src/main/java/com/legiti/services/LegitiService.kt
@@ -68,12 +68,19 @@ interface LegitiService {
     /**
      * Set config to Legiti
      *
-     * @param trackerName
-     * @param appId
-     * @param devEnv
+     * @param authToken
+     * @param legitiDevEnv
      * @return void
      */
     fun setup(authToken: String, legitiDevEnv: Boolean = false)
+
+    /**
+     * Set config to Legiti
+     *
+     * @param authToken
+     * @return void
+     */
+    fun setup(authToken: String)
 
     /**
      * Verify if config exists

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "legiti-android",
+  "version": "1.0.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "git-cz": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/git-cz/-/git-cz-4.7.0.tgz",
+      "integrity": "sha512-+igNdYIuGe8zncCb6gRxEfZ14Ru0SrI+7rXOueadxBWEn3zkBd3xyTE1RjG6qM3GY+0U7vN8DmT7o9CRcyR++A==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "legiti-android",
+  "version": "1.0.3",
+  "description": "Legiti Antifraud Library for Android",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/legiti/legiti-android.git"
+  },
+  "author": "Legiti Dev Team",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/legiti/legiti-android/issues"
+  },
+  "homepage": "https://github.com/legiti/legiti-android#readme",
+  "devDependencies": {
+    "git-cz": "^4.7.0"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/git-cz"
+    }
+  }
+}


### PR DESCRIPTION
Deprecating: `trackPasswordReset` function
Hiding the `legitiDevEnv`:  From now on to send a request to staging the authToken should start with `internal_`